### PR TITLE
Fix project path errors in scaffolded dockerfile

### DIFF
--- a/Web/Dockerfile
+++ b/Web/Dockerfile
@@ -9,9 +9,9 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
-COPY ["Web/Web.csproj", "Web/"]
+COPY ["./Web.csproj", "Web/"]
 RUN dotnet restore "./Web/Web.csproj"
-COPY . .
+COPY . ./Web
 WORKDIR "/src/Web"
 RUN dotnet build "./Web.csproj" -c $BUILD_CONFIGURATION -o /app/build
 


### PR DESCRIPTION
The Dockerfile that was generated during the project scaffolding contained invalid paths to the Web project. This PR fixes these errors.