### PR TITLE
Authorization using ASP.NET Core Identity

### DIFF
--- a/Web.IntegrationTests/AuthorizeTests.cs
+++ b/Web.IntegrationTests/AuthorizeTests.cs
@@ -49,6 +49,44 @@ internal class AuthorizeTests
         controllerCallbackResp.Headers.Location.Should().NotBeNull();
     }
 
+    [Test]
+    public async Task CanLogoutWhenAuthorized()
+    {
+        using var client = new WebApplicationFactory()
+            .WithWebHostBuilder(ConfigureDiscordAuthForTesting)
+            .CreateClient(clientOptions);
+
+        // Use a smaller version of the CanAuthorizeWithANewAccount test to authorize the user
+        // This is necessary because the user must be authorized to log out
+        // That behavior means this test doubles as an integration test for authorization checking
+        using var initiateDiscordAuthReq = new HttpRequestMessage(HttpMethod.Get, "login");
+        using var initiateDiscordAuthResp = await client.SendAsync(initiateDiscordAuthReq);
+        var queryParams = UriHelpers.GetQueryParams(initiateDiscordAuthResp.Headers.Location!);
+
+        var authHandlerUri = new UriBuilder(Uri.UnescapeDataString(queryParams["redirect_uri"]));
+        authHandlerUri.Query += $"state={queryParams["state"]}&code=1234";
+        using var discordCallbackReq = new HttpRequestMessage(HttpMethod.Post, authHandlerUri.Uri);
+        using var discordCallbackResp = await client.SendAsync(discordCallbackReq);
+
+        using var controllerCallbackReq = new HttpRequestMessage(HttpMethod.Get, discordCallbackResp.Headers.Location!);
+        using var controllerCallbackResp = await client.SendAsync(controllerCallbackReq);
+
+        // Now that the user is authorized, log out
+        using var logoutReq = new HttpRequestMessage(HttpMethod.Get, "logout");
+        using var logoutResp = await client.SendAsync(logoutReq);
+        logoutResp.Should().BeRedirection();
+    }
+
+    [Test]
+    public async Task CannotLogoutWhenNotAuthorized()
+    {
+        using var client = new WebApplicationFactory()
+            .CreateClient(clientOptions);
+
+        using var loginReq = new HttpRequestMessage(HttpMethod.Get, "logout");
+        using var loginResp = await client.SendAsync(loginReq);
+        loginResp.Should().Be401Unauthorized();
+    }
     static void ConfigureDiscordAuthForTesting(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
     {
         builder.ConfigureServices(services =>

--- a/Web.IntegrationTests/AuthorizeTests.cs
+++ b/Web.IntegrationTests/AuthorizeTests.cs
@@ -1,0 +1,122 @@
+﻿using AspNet.Security.OAuth.Discord;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net;
+using System.Net.Http.Json;
+using Web.IntegrationTests.Common;
+
+namespace Web.IntegrationTests;
+internal class AuthorizeTests
+{
+    static readonly WebApplicationFactoryClientOptions clientOptions = new()
+    {
+        AllowAutoRedirect = false, // Don't follow redirects so they can be asserted
+    };
+
+    [Test]
+    public async Task CanAuthorizeWithANewAccount()
+    {
+        using var client = new WebApplicationFactory()
+            .WithWebHostBuilder(ConfigureDiscordAuthForTesting)
+            .CreateClient(clientOptions);
+
+        // First, initiate the Discord authentication flow
+        // This will redirect to Discord's OAuth2 authorization endpoint
+        // A correlation cookie is set, so this step is necessary even during testing
+        using var initiateDiscordAuthReq = new HttpRequestMessage(HttpMethod.Get, "login");
+        using var initiateDiscordAuthResp = await client.SendAsync(initiateDiscordAuthReq);
+        initiateDiscordAuthResp.Should().BeRedirection();
+        initiateDiscordAuthResp.Should().HaveHeader("Location");
+        initiateDiscordAuthResp.Headers.Location.Should().NotBeNull()
+            .And.StartWith("https://discord.com/api/oauth2/authorize");
+        var discordToAuthHandlerRedirectUri = initiateDiscordAuthResp.Headers.Location.Should().HaveQueryParameter("redirect_uri").Subject;
+        var state = initiateDiscordAuthResp.Headers.Location.Should().HaveQueryParameter("state").Subject;
+
+        // Then, simulate the redirect from Discord to the authentication handler
+        var authHandlerUri = new UriBuilder(Uri.UnescapeDataString(discordToAuthHandlerRedirectUri));
+        authHandlerUri.Query += $"state={state}&code=1234";
+        using var discordCallbackReq = new HttpRequestMessage(HttpMethod.Post, authHandlerUri.Uri);
+        using var discordCallbackResp = await client.SendAsync(discordCallbackReq);
+        discordCallbackResp.Should().BeRedirection();
+        discordCallbackResp.Headers.Location.Should().StartWith("/login-callback")
+            .And.HaveQueryParameter("returnUrl");
+
+        // Finally, simulate the redirect from the authentication handler to the controller
+        using var controllerCallbackReq = new HttpRequestMessage(HttpMethod.Get, discordCallbackResp.Headers.Location!);
+        using var controllerCallbackResp = await client.SendAsync(controllerCallbackReq);
+        controllerCallbackResp.Should().BeRedirection();
+        controllerCallbackResp.Headers.Location.Should().NotBeNull();
+    }
+
+    static void ConfigureDiscordAuthForTesting(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            services.Configure<DiscordAuthenticationOptions>(DiscordAuthenticationDefaults.AuthenticationScheme, opts =>
+            {
+                opts.BackchannelHttpHandler = new DiscordAuthHttpMessageHandler();
+                // The test server doesn't support HTTPS, so disable secure cookies
+                opts.CorrelationCookie.SecurePolicy = Microsoft.AspNetCore.Http.CookieSecurePolicy.None; 
+                opts.CorrelationCookie.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.None;
+            });
+            services.ConfigureApplicationCookie(opts =>
+            {
+                // The test server doesn't support HTTPS, so disable secure cookies
+                opts.Cookie.SecurePolicy = Microsoft.AspNetCore.Http.CookieSecurePolicy.None;
+                opts.Cookie.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.None;
+            });
+            services.ConfigureExternalCookie(opts =>
+            {
+                // The test server doesn't support HTTPS, so disable secure cookies
+                opts.Cookie.SecurePolicy = Microsoft.AspNetCore.Http.CookieSecurePolicy.None;
+                opts.Cookie.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.None;
+            });
+        });
+    }
+
+    class DiscordAuthHttpMessageHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            static HttpResponseMessage JsonResponse(HttpStatusCode statusCode, object content) =>
+                new(statusCode) { Content = JsonContent.Create(content) };
+
+            if (request.RequestUri is not null && request.RequestUri.AbsoluteUri.StartsWith("https://discord.com/api/oauth2/token"))
+            {
+                var formData = await request.Content.ReadAsFormDataAsync(cancellationToken);
+                if (formData["grant_type"] != "authorization_code")
+                    return JsonResponse(HttpStatusCode.BadRequest, new { error = "invalid_request" });
+
+                if (formData["code"] != "1234")
+                    return JsonResponse(HttpStatusCode.BadRequest, new { error = "invalid_grant" });
+
+                return JsonResponse(HttpStatusCode.OK, new
+                {
+                    access_token = "abcdefghijklmnopqrstuvwxyz",
+                    refresh_token = "1234567890",
+                    expires_in = 3600,
+                    token_type = "Bearer",
+                    scope = "identity"
+                });
+            }
+
+            if (request.RequestUri is not null && request.RequestUri.AbsoluteUri.StartsWith("https://discord.com/api/users/@me"))
+            {
+                if (request.Headers.Authorization?.Scheme != "Bearer" || request.Headers.Authorization.Parameter != "abcdefghijklmnopqrstuvwxyz")
+                    return new HttpResponseMessage(HttpStatusCode.Unauthorized);
+
+                return JsonResponse(HttpStatusCode.OK, new
+                {
+                    id = "1",
+                    username = "discord",
+                    avatar = "abcd",
+                    discriminator = "0",
+                    global_name = "Discord",
+                });
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }
+    }
+}

--- a/Web.IntegrationTests/Common/UriAssertions.cs
+++ b/Web.IntegrationTests/Common/UriAssertions.cs
@@ -1,0 +1,39 @@
+﻿using FluentAssertions;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+
+namespace Web.IntegrationTests.Common; 
+
+public static class UriExtensions
+{
+    public static UriAssertions Should(this Uri? instance)
+    {
+        return new UriAssertions(instance);
+    }
+}
+
+public class UriAssertions(Uri? instance) : ReferenceTypeAssertions<Uri, UriAssertions>(instance!)
+{
+    protected override string Identifier => "uri";
+
+    [CustomAssertion]
+    public AndConstraint<UriAssertions> StartWith(string expected, string because = "", params object[] becauseArgs)
+    {
+        Execute.Assertion
+            .ForCondition(Subject.ToString().StartsWith(expected))
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:uri} to start with {0}{reason}, but found {1}.", expected, Subject.ToString());
+        return new AndConstraint<UriAssertions>(this);
+    }
+
+    [CustomAssertion]
+    public AndWhichConstraint<UriAssertions, string> HaveQueryParameter(string name, string because = "", params object[] becauseArgs)
+    {
+        var queryParams = UriHelpers.GetQueryParams(Subject);
+        Execute.Assertion
+            .ForCondition(queryParams.ContainsKey(name))
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected {context:uri} to have query parameter {0}{reason}, but found {1}.", name, queryParams);
+        return new AndWhichConstraint<UriAssertions, string>(this, queryParams[name]);
+    }
+}

--- a/Web.IntegrationTests/Common/UriHelpers.cs
+++ b/Web.IntegrationTests/Common/UriHelpers.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Web.IntegrationTests.Common;
+internal class UriHelpers
+{
+    public static Dictionary<string, string> GetQueryParams(Uri uri)
+    {
+        if (!uri.IsAbsoluteUri)
+        {
+            uri = new(new Uri("http://localhost"), uri.ToString());
+        }
+        return uri.Query.TrimStart('?').Split('&').Select(qp => qp.Split('=')).ToDictionary(qp => qp[0], qp => qp[1]);
+    }
+}

--- a/Web.IntegrationTests/Common/WebApplicationFactory.cs
+++ b/Web.IntegrationTests/Common/WebApplicationFactory.cs
@@ -12,7 +12,8 @@ internal class WebApplicationFactory : WebApplicationFactory<Program>
     {
         var configDict = new Dictionary<string, string?>
         {
-            { "ConnectionStrings:DriverDatabaseContext", "Data Source=fiadriverdatabase.db" }
+            { "ConnectionStrings:DriverDatabaseContext", "Data Source=fiadriverdatabase.db" },
+            { "Database:MigrateOnStartup", "false" }
         };
         builder.ConfigureAppConfiguration(config => config.AddInMemoryCollection(configDict));
     }

--- a/Web.UnitTests/Controllers/AuthorizeControllerTests.cs
+++ b/Web.UnitTests/Controllers/AuthorizeControllerTests.cs
@@ -1,0 +1,131 @@
+﻿using AspNet.Security.OAuth.Discord;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using NSubstitute;
+using NSubstitute.ReturnsExtensions;
+using System.Security.Claims;
+using Web.Controllers;
+using Web.UnitTests.Fakes;
+using SignInResult = Microsoft.AspNetCore.Identity.SignInResult;
+
+namespace Web.UnitTests.Controllers;
+internal class AuthorizeControllerTests
+{
+    class FakeUriHelper : IUrlHelper
+    {
+        public ActionContext ActionContext => throw new NotImplementedException();
+        public IServiceProvider Services => throw new NotImplementedException();
+        public string Action(UrlActionContext actionContext)
+        {
+            return "/login-callback";
+        }
+        public string Content(string contentPath)
+        {
+            throw new NotImplementedException();
+        }
+        public bool IsLocalUrl(string url)
+        {
+            throw new NotImplementedException();
+        }
+        public string Link(string routeName, object values)
+        {
+            throw new NotImplementedException();
+        }
+        public string RouteUrl(UrlRouteContext routeContext)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    [Test]
+    public async Task Login_RedirectsToDiscord()
+    {
+        var (signInManager, userManager, userStore) = IdentityFakesFactory.CreateIdentityServices();
+        var sut = new AuthorizeController(signInManager, userManager, userStore)
+        {
+            Url = new FakeUriHelper()
+        };
+        var result = (sut.Login()).Should().BeOfType<ChallengeResult>().Subject;
+        result.AuthenticationSchemes.Should().Contain(DiscordAuthenticationDefaults.AuthenticationScheme);
+    }
+
+    [Test]
+    public async Task LoginCompleted_MissingExternalLoginInfo_ReturnsBadRequest()
+    {
+        var (signInManager, userManager, userStore) = IdentityFakesFactory.CreateIdentityServices();
+        signInManager.GetExternalLoginInfoAsync().ReturnsNull();
+        var sut = new AuthorizeController(signInManager, userManager, userStore)
+        {
+            Url = new FakeUriHelper()
+        };
+        (await sut.LoginCompleted()).Should().BeOfType<BadRequestResult>();
+    }
+
+    [Test]
+    public async Task LoginCompleted_ExistingUser_RedirectsToReturnUrl()
+    {
+        var (signInManager, userManager, userStore) = IdentityFakesFactory.CreateIdentityServices();
+        signInManager.GetExternalLoginInfoAsync().Returns(new ExternalLoginInfo(new ClaimsPrincipal(), DiscordAuthenticationDefaults.AuthenticationScheme, "1", "Discord") { AuthenticationProperties = new() });
+        signInManager.ExternalLoginSignInAsync("Discord", "1", true, true).Returns(SignInResult.Success);
+        var sut = new AuthorizeController(signInManager, userManager, userStore)
+        {
+            Url = new FakeUriHelper()
+        };
+        var result = (await sut.LoginCompleted()).Should().BeOfType<RedirectResult>().Subject;
+        result.Url.Should().Be("/");
+    }
+
+    [Test, TestCaseSource(typeof(AuthorizeControllerTests), nameof(LoginCompleted_LockedOutOrNotAllowedUser_ReturnsForbidden_Cases))]
+    public async Task LoginCompleted_LockedOutOrNotAllowedUser_ReturnsForbidden(SignInResult signInResult)
+    {
+        var (signInManager, userManager, userStore) = IdentityFakesFactory.CreateIdentityServices();
+        signInManager.GetExternalLoginInfoAsync().Returns(new ExternalLoginInfo(new ClaimsPrincipal(), DiscordAuthenticationDefaults.AuthenticationScheme, "1", "Discord") { AuthenticationProperties = new() });
+        signInManager.ExternalLoginSignInAsync("Discord", "1", true, true).Returns(signInResult);
+        var sut = new AuthorizeController(signInManager, userManager, userStore)
+        {
+            Url = new FakeUriHelper()
+        };
+        var result = (await sut.LoginCompleted()).Should().BeOfType<StatusCodeResult>().Subject;
+        result.StatusCode.Should().Be(403);
+    }
+
+    [Test]
+    public async Task LoginCompleted_TwoFactorEnabledUser_ReturnsBadRequest()
+    {
+        var (signInManager, userManager, userStore) = IdentityFakesFactory.CreateIdentityServices();
+        signInManager.GetExternalLoginInfoAsync().Returns(new ExternalLoginInfo(new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, "Test") })), DiscordAuthenticationDefaults.AuthenticationScheme, "1", "Discord") { AuthenticationProperties = new() });
+        signInManager.ExternalLoginSignInAsync("Discord", "1", true, true).Returns(SignInResult.TwoFactorRequired);
+        var sut = new AuthorizeController(signInManager, userManager, userStore)
+        {
+            Url = new FakeUriHelper()
+        };
+        (await sut.LoginCompleted()).Should().BeOfType<BadRequestResult>();
+    }
+
+    [Test]
+    public async Task LoginCompleted_NewUser_CreatesUserAndRedirectsToReturnUrl()
+    {
+        var (signInManager, userManager, userStore) = IdentityFakesFactory.CreateIdentityServices();
+        signInManager.GetExternalLoginInfoAsync().Returns(new ExternalLoginInfo(new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "Test")])), DiscordAuthenticationDefaults.AuthenticationScheme, "1", "Discord") { AuthenticationProperties = new() });
+        signInManager.ExternalLoginSignInAsync("Discord", "1", true, true).Returns(SignInResult.Failed); // 'failed' really means 'user does not exist'
+        signInManager.SignInAsync(Arg.Any<IdentityUser>(), Arg.Any<AuthenticationProperties>(), DiscordAuthenticationDefaults.AuthenticationScheme).Returns(Task.CompletedTask);
+        userManager.CreateAsync(Arg.Any<IdentityUser>()).Returns(IdentityResult.Success);
+        userManager.AddLoginAsync(Arg.Any<IdentityUser>(), Arg.Any<ExternalLoginInfo>()).Returns(IdentityResult.Success);
+        userManager.AddClaimsAsync(Arg.Any<IdentityUser>(), Arg.Any<IEnumerable<Claim>>()).Returns(IdentityResult.Success);
+        var sut = new AuthorizeController(signInManager, userManager, userStore)
+        {
+            Url = new FakeUriHelper()
+        };
+        var result = (await sut.LoginCompleted()).Should().BeOfType<RedirectResult>().Subject;
+        result.Url.Should().Be("/");
+    }
+
+    static IEnumerable<TestCaseData> LoginCompleted_LockedOutOrNotAllowedUser_ReturnsForbidden_Cases()
+    {
+        yield return new(SignInResult.LockedOut);
+        yield return new(SignInResult.NotAllowed);
+    }
+}

--- a/Web.UnitTests/Fakes/IdentityFakesFactory.cs
+++ b/Web.UnitTests/Fakes/IdentityFakesFactory.cs
@@ -1,0 +1,181 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using System.Security.Claims;
+
+namespace Web.UnitTests.Fakes;
+internal class IdentityFakesFactory
+{
+    public static SignInManager<IdentityUser> CreateSignInManager()
+    {
+        return CreateSignInManager(CreateUserManager());
+    }
+
+    public static SignInManager<IdentityUser> CreateSignInManager(UserManager<IdentityUser> userManager)
+    {
+        return Substitute.For<SignInManager<IdentityUser>>(
+            userManager,
+            new FakeHttpContextAccessor(),
+            new UserClaimsPrincipalFactory<IdentityUser>(userManager, new FakeOptionsAccessor<IdentityOptions>()),
+            new FakeOptionsAccessor<IdentityOptions>(),
+            new NullLogger<SignInManager<IdentityUser>>(),
+            new AuthenticationSchemeProvider(new FakeOptionsAccessor<AuthenticationOptions>()),
+            new DefaultUserConfirmation<IdentityUser>());
+    }
+
+    public static UserManager<IdentityUser> CreateUserManager()
+    {
+        return CreateUserManager(CreateUserStore());
+    }
+
+    public static UserManager<IdentityUser> CreateUserManager(IUserStore<IdentityUser> userStore)
+    {
+        return Substitute.For<FakeUserManager<IdentityUser>>(
+            userStore,
+            new FakeOptionsAccessor<IdentityOptions>(),
+            new PasswordHasher<IdentityUser>(),
+            Array.Empty<IUserValidator<IdentityUser>>(),
+            Array.Empty<IPasswordValidator<IdentityUser>>(),
+            new UpperInvariantLookupNormalizer(),
+            new IdentityErrorDescriber(),
+            new ServiceCollection().BuildServiceProvider(),
+            new NullLogger<UserManager<IdentityUser>>());
+    }
+
+    public static IUserStore<IdentityUser> CreateUserStore()
+    {
+        return Substitute.For<FakeUserStore>();
+    }
+
+    public static (SignInManager<IdentityUser>, UserManager<IdentityUser>, IUserStore<IdentityUser>) CreateIdentityServices()
+    {
+        var userStore = CreateUserStore();
+        var userManager = CreateUserManager(userStore);
+        var signInManager = CreateSignInManager(userManager);
+        return (signInManager, userManager, userStore);
+    }
+}
+
+public class FakeSignInManager<TUser> : SignInManager<TUser> where TUser : class
+{
+    public FakeSignInManager(
+        UserManager<TUser> userManager,
+        IHttpContextAccessor contextAccessor,
+        IUserClaimsPrincipalFactory<TUser> claimsFactory,
+        IOptions<IdentityOptions> optionsAccessor,
+        ILogger<SignInManager<TUser>> logger,
+        IAuthenticationSchemeProvider schemes,
+        IUserConfirmation<TUser> confirmation)
+        : base(userManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation)
+    {
+    }
+}
+
+public class FakeUserManager<TUser> : UserManager<TUser> where TUser : class
+{
+    public FakeUserManager(
+        IUserStore<TUser> store,
+        IOptions<IdentityOptions> optionsAccessor,
+        IPasswordHasher<TUser> passwordHasher,
+        IEnumerable<IUserValidator<TUser>> userValidators,
+        IEnumerable<IPasswordValidator<TUser>> passwordValidators,
+        ILookupNormalizer keyNormalizer,
+        IdentityErrorDescriber errors,
+        IServiceProvider services,
+        ILogger<UserManager<TUser>> logger)
+        : base(store, optionsAccessor, passwordHasher, userValidators, passwordValidators, keyNormalizer, errors, services, logger)
+    {
+    }
+}
+
+class FakeHttpContextAccessor : IHttpContextAccessor
+{
+    public HttpContext? HttpContext { get; set; }
+}
+
+class FakeHttpContext : HttpContext
+{
+    public override IServiceProvider RequestServices { get; set; }
+
+    public override IFeatureCollection Features => throw new NotImplementedException();
+
+    public override HttpRequest Request => throw new NotImplementedException();
+
+    public override HttpResponse Response => throw new NotImplementedException();
+
+    public override ConnectionInfo Connection => throw new NotImplementedException();
+
+    public override WebSocketManager WebSockets => throw new NotImplementedException();
+
+    public override ClaimsPrincipal User { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+    public override IDictionary<object, object?> Items { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+    public override CancellationToken RequestAborted { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+    public override string TraceIdentifier { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+    public override ISession Session { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+    public override void Abort() => throw new NotImplementedException();
+}
+
+class FakeOptionsAccessor<TOptions> : IOptions<TOptions> where TOptions : class, new()
+{
+    readonly TOptions _value;
+    public FakeOptionsAccessor(TOptions? value = null)
+    {
+        _value = value ?? new TOptions();
+    }
+    public TOptions Value => _value;
+}
+
+public class FakeUserStore : IUserStore<IdentityUser>
+{
+    public Task<IdentityResult> CreateAsync(IdentityUser user, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(IdentityResult.Success);
+    }
+    public Task<IdentityResult> DeleteAsync(IdentityUser user, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(IdentityResult.Success);
+    }
+    public void Dispose()
+    {
+        return;
+    }
+    public Task<IdentityUser> FindByIdAsync(string userId, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+    public Task<IdentityUser> FindByNameAsync(string normalizedUserName, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+    public Task<string> GetNormalizedUserNameAsync(IdentityUser user, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+    public Task<string> GetUserIdAsync(IdentityUser user, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+    public Task<string> GetUserNameAsync(IdentityUser user, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+    public Task SetNormalizedUserNameAsync(IdentityUser user, string normalizedName, CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+    public Task SetUserNameAsync(IdentityUser user, string userName, CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+    public Task<IdentityResult> UpdateAsync(IdentityUser user, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(IdentityResult.Success);
+    }
+}

--- a/Web.UnitTests/Web.UnitTests.csproj
+++ b/Web.UnitTests/Web.UnitTests.csproj
@@ -16,6 +16,11 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Web/Controllers/AuthorizeController.cs
+++ b/Web/Controllers/AuthorizeController.cs
@@ -1,0 +1,62 @@
+﻿using AspNet.Security.OAuth.Discord;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace Web.Controllers;
+
+public class AuthorizeController(SignInManager<IdentityUser> signInManager, UserManager<IdentityUser> userManager, IUserStore<IdentityUser> userStore) : ControllerBase
+{
+    readonly SignInManager<IdentityUser> signInManager = signInManager;
+    readonly UserManager<IdentityUser> userManager = userManager;
+    readonly IUserStore<IdentityUser> userStore = userStore;
+
+    [HttpGet("/login"), AllowAnonymous]
+    public IActionResult Login([FromQuery] string returnUrl = "/")
+    {
+        var redirectUri = Url.Action(nameof(LoginCompleted), new { returnUrl });
+        var properties = signInManager.ConfigureExternalAuthenticationProperties(DiscordAuthenticationDefaults.AuthenticationScheme, redirectUri);
+        return Challenge(properties, DiscordAuthenticationDefaults.AuthenticationScheme);
+    }
+
+    [HttpGet("/login-callback"), ApiExplorerSettings(IgnoreApi = true), AllowAnonymous]
+    public async Task<IActionResult> LoginCompleted([FromQuery] string returnUrl = "/")
+    {
+        if (await signInManager.GetExternalLoginInfoAsync() is not { AuthenticationProperties: not null } info)
+            return BadRequest();
+
+        var signInResult = await signInManager.ExternalLoginSignInAsync(info.LoginProvider, info.ProviderKey, isPersistent: true, bypassTwoFactor: true);
+        if (signInResult.Succeeded)
+        {
+            return Redirect(returnUrl);
+        }
+        else if (signInResult.IsLockedOut || signInResult.IsNotAllowed)
+        {
+            return StatusCode(403);
+        }
+        else if (signInResult.RequiresTwoFactor)
+        {
+            // There's no two-factor mechanism enabled in the application, so always return an error
+            return BadRequest();
+        }
+        else // The user has no account yet
+        {
+            var user = new IdentityUser();
+            await userStore.SetUserNameAsync(user, info.Principal.FindFirstValue(ClaimTypes.Name), CancellationToken.None);
+            // The error cases below should ideally be handled gracefully
+            // But for now there's no reason why they should occur other than application errors
+            if (await userManager.CreateAsync(user) is { Succeeded: false })
+                throw new Exception();
+
+            if (await userManager.AddLoginAsync(user, info) is { Succeeded: false })
+                throw new Exception();
+
+            if (await userManager.AddClaimsAsync(user, info.Principal.Claims) is { Succeeded: false })
+                throw new Exception();
+
+            await signInManager.SignInAsync(user, info.AuthenticationProperties, DiscordAuthenticationDefaults.AuthenticationScheme);
+            return Redirect(returnUrl);
+        }
+    }
+}

--- a/Web/Controllers/AuthorizeController.cs
+++ b/Web/Controllers/AuthorizeController.cs
@@ -59,4 +59,11 @@ public class AuthorizeController(SignInManager<IdentityUser> signInManager, User
             return Redirect(returnUrl);
         }
     }
+
+    [HttpGet("/logout"), Authorize]
+    public async Task<IActionResult> Logout()
+    {
+        await signInManager.SignOutAsync();
+        return Redirect("/");
+    }
 }

--- a/Web/DriverDatabaseIdentityExtensions.cs
+++ b/Web/DriverDatabaseIdentityExtensions.cs
@@ -1,0 +1,116 @@
+﻿using AspNet.Security.OAuth.Discord;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Web.Model.EF;
+
+namespace Web;
+
+static class DriverDatabaseIdentityExtensions
+{
+    public static IServiceCollection AddDriverDatabaseIdentity(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddIdentity<IdentityUser, IdentityRole>()
+            .AddEntityFrameworkStores<DriverDatabaseContext>();
+
+        services.ConfigureApplicationCookie(opts =>
+        {
+            opts.LoginPath = "/login";
+            opts.Events.OnValidatePrincipal = ProxyEvent(ValidateRemotePrincipal, opts.Events.OnValidatePrincipal);
+            opts.Events.OnRedirectToLogin = context =>
+            {
+                context.Response.Headers.WWWAuthenticate = "Discord";
+                context.Response.Headers.Location = context.RedirectUri;
+                context.Response.StatusCode = 401;
+                return Task.CompletedTask;
+            };
+        });
+
+        services.ConfigureExternalCookie(opts =>
+        {
+            // It's safe to keep the expiry cookie for a long time, because the refresh token is validated each day
+            opts.ExpireTimeSpan = TimeSpan.FromDays(180);
+            opts.SlidingExpiration = true;
+        });
+
+        services.AddAuthentication()
+            .AddDiscord(options =>
+            {
+                var discordAuthSection = configuration.GetSection("Authentication:Discord");
+                options.ClientId = discordAuthSection["ClientId"] ?? string.Empty;
+                options.ClientSecret = discordAuthSection["ClientSecret"] ?? string.Empty;
+                options.SaveTokens = true; // Refresh tokens need to be remembered
+                options.Prompt = "none"; // Does not require explicit action from the user when the user has authenticated the application in the past
+            });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Validates the User Principal against Discord
+    /// </summary>
+    /// <param name="context"></param>
+    /// <returns></returns>
+    static async Task ValidateRemotePrincipal(CookieValidatePrincipalContext context)
+    {
+        // If the token is at least a day old, refresh access token
+        // This ensures that users can't use a retracted token for too long
+        // A day is honestly still quite long, so this should probably be less
+        if (context.Properties.IssuedUtc < TimeProvider.System.GetUtcNow().AddDays(-1)
+            && context.Properties.GetTokenValue("refresh_token") is string refreshToken
+            && !string.IsNullOrEmpty(refreshToken))
+        {
+            var discordOptions = context.HttpContext.RequestServices.GetRequiredService<IOptionsSnapshot<DiscordAuthenticationOptions>>().Get(DiscordAuthenticationDefaults.AuthenticationScheme);
+
+            var body = new Dictionary<string, string> {
+                { "client_id", discordOptions.ClientId },
+                { "client_secret", discordOptions.ClientSecret },
+                { "refresh_token", refreshToken },
+                { "grant_type", "refresh_token" },
+            };
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, discordOptions.TokenEndpoint) { Content = new FormUrlEncodedContent(body) };
+            using var response = await discordOptions.Backchannel.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                // On a bad request status the refresh code was likely invalid
+                // At this point it should be assumed the user has retracted permission, and should not be authorized in case of account abuse
+                if (response.StatusCode == System.Net.HttpStatusCode.BadRequest)
+                    context.RejectPrincipal();
+
+                context.Properties.UpdateTokenValue("refresh_token", string.Empty);
+                return;
+            }
+
+            var tokenResponse = JsonSerializer.Deserialize<DiscordTokenResponse>(await response.Content.ReadAsStreamAsync())!;
+            context.Properties.UpdateTokenValue("access_token", tokenResponse.AccessToken);
+            if (tokenResponse.RefreshToken is not null)
+                context.Properties.UpdateTokenValue("refresh_token", tokenResponse.RefreshToken);
+            context.Properties.ExpiresUtc = DateTimeOffset.UtcNow.Add(tokenResponse.ExpiresIn);
+
+            context.ShouldRenew = true;
+        }
+    }
+
+    static Func<T, Task> ProxyEvent<T>(Func<T, Task> newHandler, Func<T, Task> originalHandler)
+    {
+        return async (context) =>
+        {
+            if (newHandler != null)
+                await newHandler(context);
+            if (originalHandler != null)
+                await originalHandler(context);
+        };
+    }
+
+    record class DiscordTokenResponse(
+        [property: JsonPropertyName("access_token")] string AccessToken,
+        [property: JsonPropertyName("refresh_token")] string RefreshToken,
+        [property: JsonPropertyName("expires_in")] int ExpiresInSeconds)
+    {
+        public TimeSpan ExpiresIn => TimeSpan.FromSeconds(ExpiresInSeconds);
+    }
+}

--- a/Web/Migrations/20241129195326_AddAspNetCoreIdentity.Designer.cs
+++ b/Web/Migrations/20241129195326_AddAspNetCoreIdentity.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Web.Model.EF;
 
@@ -10,9 +11,11 @@ using Web.Model.EF;
 namespace Web.Migrations
 {
     [DbContext(typeof(DriverDatabaseContext))]
-    partial class DriverDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20241129195326_AddAspNetCoreIdentity")]
+    partial class AddAspNetCoreIdentity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.11");

--- a/Web/Migrations/20241129195326_AddAspNetCoreIdentity.cs
+++ b/Web/Migrations/20241129195326_AddAspNetCoreIdentity.cs
@@ -1,0 +1,222 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Web.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAspNetCoreIdentity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AspNetRoles",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                    NormalizedName = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                    ConcurrencyStamp = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetRoles", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUsers",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "TEXT", nullable: false),
+                    UserName = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                    NormalizedUserName = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                    Email = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                    NormalizedEmail = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                    EmailConfirmed = table.Column<bool>(type: "INTEGER", nullable: false),
+                    PasswordHash = table.Column<string>(type: "TEXT", nullable: true),
+                    SecurityStamp = table.Column<string>(type: "TEXT", nullable: true),
+                    ConcurrencyStamp = table.Column<string>(type: "TEXT", nullable: true),
+                    PhoneNumber = table.Column<string>(type: "TEXT", nullable: true),
+                    PhoneNumberConfirmed = table.Column<bool>(type: "INTEGER", nullable: false),
+                    TwoFactorEnabled = table.Column<bool>(type: "INTEGER", nullable: false),
+                    LockoutEnd = table.Column<DateTimeOffset>(type: "TEXT", nullable: true),
+                    LockoutEnabled = table.Column<bool>(type: "INTEGER", nullable: false),
+                    AccessFailedCount = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUsers", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetRoleClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    RoleId = table.Column<string>(type: "TEXT", nullable: false),
+                    ClaimType = table.Column<string>(type: "TEXT", nullable: true),
+                    ClaimValue = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetRoleClaims", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AspNetRoleClaims_AspNetRoles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "AspNetRoles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    UserId = table.Column<string>(type: "TEXT", nullable: false),
+                    ClaimType = table.Column<string>(type: "TEXT", nullable: true),
+                    ClaimValue = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserClaims", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AspNetUserClaims_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserLogins",
+                columns: table => new
+                {
+                    LoginProvider = table.Column<string>(type: "TEXT", nullable: false),
+                    ProviderKey = table.Column<string>(type: "TEXT", nullable: false),
+                    ProviderDisplayName = table.Column<string>(type: "TEXT", nullable: true),
+                    UserId = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserLogins", x => new { x.LoginProvider, x.ProviderKey });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserLogins_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserRoles",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "TEXT", nullable: false),
+                    RoleId = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserRoles", x => new { x.UserId, x.RoleId });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserRoles_AspNetRoles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "AspNetRoles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_AspNetUserRoles_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserTokens",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "TEXT", nullable: false),
+                    LoginProvider = table.Column<string>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", nullable: false),
+                    Value = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserTokens", x => new { x.UserId, x.LoginProvider, x.Name });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserTokens_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetRoleClaims_RoleId",
+                table: "AspNetRoleClaims",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "RoleNameIndex",
+                table: "AspNetRoles",
+                column: "NormalizedName",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserClaims_UserId",
+                table: "AspNetUserClaims",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserLogins_UserId",
+                table: "AspNetUserLogins",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserRoles_RoleId",
+                table: "AspNetUserRoles",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "EmailIndex",
+                table: "AspNetUsers",
+                column: "NormalizedEmail");
+
+            migrationBuilder.CreateIndex(
+                name: "UserNameIndex",
+                table: "AspNetUsers",
+                column: "NormalizedUserName",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AspNetRoleClaims");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserClaims");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserLogins");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserRoles");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserTokens");
+
+            migrationBuilder.DropTable(
+                name: "AspNetRoles");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUsers");
+        }
+    }
+}

--- a/Web/Model/EF/DriverDatabaseContext.cs
+++ b/Web/Model/EF/DriverDatabaseContext.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Web.Types;
 
 namespace Web.Model.EF;
 
-public class DriverDatabaseContext(DbContextOptions options) : DbContext(options)
+public class DriverDatabaseContext(DbContextOptions options) : IdentityDbContext(options)
 {
     public DbSet<Driver> Drivers { get; set; }
 

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -25,11 +25,12 @@ public class Program
 
         builder.Services.AddIdGen(1);
         builder.Services.AddSingleton<GenerateId>(sp => () => new(sp.GetRequiredService<IIdGenerator<long>>().CreateId()));
-
+        builder.Services.AddDriverDatabaseIdentity(builder.Configuration);
         builder.Services.AddControllers().AddJsonOptions(options =>
         {
             options.JsonSerializerOptions.Converters.Add(new SnowflakeJsonConverter());
         });
+
         // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
         builder.Services.AddEndpointsApiExplorer();
         builder.Services.AddSwaggerGen(c =>
@@ -50,8 +51,8 @@ public class Program
 
         app.UseHttpsRedirection();
 
+        app.UseAuthentication();
         app.UseAuthorization();
-
 
         app.MapControllers();
 

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -40,7 +40,10 @@ public class Program
 
         var app = builder.Build();
 
-        MigrateDatabase<DriverDatabaseContext>(app.Services);
+        if (builder.Configuration.GetValue("Database:MigrateOnStartup", false))
+        {
+            MigrateDatabase<DriverDatabaseContext>(app.Services);
+        }
 
         // Configure the HTTP request pipeline.
         if (app.Environment.IsDevelopment())

--- a/Web/Web.csproj
+++ b/Web/Web.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNet.Security.OAuth.Discord" Version="8.3.0" />
     <PackageReference Include="IdGen" Version="3.0.7" />
     <PackageReference Include="IdGen.DependencyInjection" Version="3.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.11" />

--- a/Web/Web.csproj
+++ b/Web/Web.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="IdGen" Version="3.0.7" />
     <PackageReference Include="IdGen.DependencyInjection" Version="3.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Web/appsettings.json
+++ b/Web/appsettings.json
@@ -11,6 +11,9 @@
       "ClientSecret": "in-user-secrets-see-readme"
     }
   },
+  "Database": {
+    "MigrateOnStartup": true
+  },
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "DriverDatabaseContext": "Data Source=fiadriverdatabase.db"

--- a/Web/appsettings.json
+++ b/Web/appsettings.json
@@ -5,6 +5,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Authentication": {
+    "Discord": {
+      "ClientId": "in-user-secrets-see-readme",
+      "ClientSecret": "in-user-secrets-see-readme"
+    }
+  },
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "DriverDatabaseContext": "Data Source=fiadriverdatabase.db"

--- a/Web/readme.md
+++ b/Web/readme.md
@@ -13,3 +13,8 @@ To run the container image, use the following command: `docker run --name fiadri
 To run the container image with a persistent database, add a volume mapped to the `/db` directory: `docker run --name fiadriverdb -p 8080:8080  -v fiadriverdb_db:/db lair/fiadriverdb-server:latest`
 
 To persist the database on your local machine, mount a directory to the `/db` directory: `docker run --name fiadriverdb -p 8080:8080  -v <path>:/db lair/fiadriverdb-server:latest`
+
+## Configuration
+The application can be configured using the `appsettings.json` file, environment variables, and the ASP.NET Core Secret Manager. For more information about using environment variables to replace app settings, see [Safe storage of app secrets in development in ASP.NET Core, Environment variables](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets#environment-variables). For more information about the User Secrets feature, see [Safe storage of app secrets in development in ASP.NET Core, Secret Manager](https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets#secret-manager).
+
+Usage of the Secret Manager is recommended for development.


### PR DESCRIPTION
Adds authorization logic using the ASP.NET Core Identity Framework.
Users can exclusively authorize using Discord.
Auth state is kept in a cookie to minimize developer effort in managing and refreshing state.

A separate package is used to implement Discord authorization. This package did not implement any usage of refresh tokens. This is implemented via a custom solution, taking some inspiration from https://github.com/auth0/auth0-aspnetcore-authentication.