### PR TITLE
Adds basic Teams Create/Read/Update functionality

### DIFF
--- a/Web.IntegrationTests/Common/TestUserManager.cs
+++ b/Web.IntegrationTests/Common/TestUserManager.cs
@@ -9,13 +9,17 @@ internal class TestUserManager(WebApplicationFactory webApplicationFactory, ISer
     readonly WebApplicationFactory webApplicationFactory = webApplicationFactory;
     readonly IServiceProvider serviceProvider = serviceProvider;
 
-    public async Task<IdentityUser> CreateUser(string username)
+    public async Task<IdentityUser> CreateUser(string username, string? role = null)
     {
         using var serviceScope = serviceProvider.CreateScope();
         var userManager = serviceScope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
         var currentUser = new IdentityUser();
         await userManager.SetUserNameAsync(currentUser, username);
         await userManager.CreateAsync(currentUser);
+
+        if (role is not null)
+            await userManager.AddToRoleAsync(currentUser, role);
+
         return currentUser;
     }
 

--- a/Web.IntegrationTests/Common/TestUserManager.cs
+++ b/Web.IntegrationTests/Common/TestUserManager.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using System.Security.Claims;
+
+namespace Web.IntegrationTests.Common;
+
+internal class TestUserManager(WebApplicationFactory webApplicationFactory, IServiceProvider serviceProvider)
+{
+    readonly WebApplicationFactory webApplicationFactory = webApplicationFactory;
+    readonly IServiceProvider serviceProvider = serviceProvider;
+
+    public async Task<IdentityUser> CreateUser(string username)
+    {
+        using var serviceScope = serviceProvider.CreateScope();
+        var userManager = serviceScope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+        var currentUser = new IdentityUser();
+        await userManager.SetUserNameAsync(currentUser, username);
+        await userManager.CreateAsync(currentUser);
+        return currentUser;
+    }
+
+    public async Task<ClaimsPrincipal> GetPrincipal(IdentityUser user)
+    {
+        using var serviceScope = serviceProvider.CreateScope();
+        return await GetPrincipal(user, serviceScope.ServiceProvider);
+    }
+
+    public async Task<ClaimsPrincipal> GetPrincipal(string username)
+    {
+        using var serviceScope = serviceProvider.CreateScope();
+        var userManager = serviceScope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+        return await GetPrincipal(await userManager.FindByNameAsync(username) ?? new IdentityUser("testuser"), serviceScope.ServiceProvider);
+    }
+
+    static async Task<ClaimsPrincipal> GetPrincipal(IdentityUser user, IServiceProvider serviceProvider)
+    {
+        var claimsPrincipalFactory = serviceProvider.GetRequiredService<IUserClaimsPrincipalFactory<IdentityUser>>();
+        return await claimsPrincipalFactory.CreateAsync(user);
+    }
+}

--- a/Web.IntegrationTests/Common/WebApplicationFactory.cs
+++ b/Web.IntegrationTests/Common/WebApplicationFactory.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.Mvc.Testing.Handlers;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -16,6 +17,8 @@ using Web.Model.EF;
 namespace Web.IntegrationTests.Common;
 internal class WebApplicationFactory : WebApplicationFactory<Program>
 {
+    const string TestConnectionString = "Data Source=fiadriverdatabase.db";
+
     public WebApplicationFactory() : base()
     {
         TestUsers = new TestUserManager(this, Services);
@@ -27,7 +30,7 @@ internal class WebApplicationFactory : WebApplicationFactory<Program>
     {
         var configDict = new Dictionary<string, string?>
         {
-            { "ConnectionStrings:DriverDatabaseContext", "Data Source=fiadriverdatabase.db" },
+            { "ConnectionStrings:DriverDatabaseContext", TestConnectionString },
             { "Database:MigrateOnStartup", "false" }
         };
         builder.ConfigureAppConfiguration(config => config.AddInMemoryCollection(configDict));
@@ -35,11 +38,12 @@ internal class WebApplicationFactory : WebApplicationFactory<Program>
 
     protected override IHost CreateHost(IHostBuilder builder)
     {
-        var host = base.CreateHost(builder);
-        using var scope = host.Services.CreateScope();
-        scope.ServiceProvider.GetRequiredService<DriverDatabaseContext>().Database.EnsureDeleted();
-        scope.ServiceProvider.GetRequiredService<DriverDatabaseContext>().Database.EnsureCreated();
-        return host;
+        using var dbContext = new DriverDatabaseContext(new DbContextOptionsBuilder<DriverDatabaseContext>()
+            .UseSqlite(TestConnectionString)
+            .Options);
+        dbContext.Database.EnsureDeleted();
+        dbContext.Database.EnsureCreated();
+        return base.CreateHost(builder);
     }
 
     public HttpClient CreateAuthenticatedClient(ClaimsPrincipal principal)

--- a/Web.IntegrationTests/Common/WebApplicationFactory.cs
+++ b/Web.IntegrationTests/Common/WebApplicationFactory.cs
@@ -1,13 +1,28 @@
-﻿using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Mvc.Testing.Handlers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Net.Http.Headers;
+using System.Net;
+using System.Security.Claims;
 using Web.Model.EF;
 
 namespace Web.IntegrationTests.Common;
 internal class WebApplicationFactory : WebApplicationFactory<Program>
 {
+    public WebApplicationFactory() : base()
+    {
+        TestUsers = new TestUserManager(this, Services);
+    }
+
+    public TestUserManager TestUsers { get; }
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         var configDict = new Dictionary<string, string?>
@@ -25,5 +40,61 @@ internal class WebApplicationFactory : WebApplicationFactory<Program>
         scope.ServiceProvider.GetRequiredService<DriverDatabaseContext>().Database.EnsureDeleted();
         scope.ServiceProvider.GetRequiredService<DriverDatabaseContext>().Database.EnsureCreated();
         return host;
+    }
+
+    public HttpClient CreateAuthenticatedClient(ClaimsPrincipal principal)
+        => CreateAuthenticatedClient(principal, new());
+
+    public HttpClient CreateAuthenticatedClient(ClaimsPrincipal principal, WebApplicationFactoryClientOptions clientOptions)
+    {
+        using var serviceScope = Services.CreateScope();
+        var authProperties = new AuthenticationProperties()
+        {
+            ExpiresUtc = DateTimeOffset.Now.AddDays(1),
+            IssuedUtc = DateTimeOffset.Now,
+            Items =
+            {
+                new KeyValuePair<string, string?>(".AuthScheme", "Discord"),
+                new KeyValuePair<string, string?>("LoginProvider", "Discord"),
+                new KeyValuePair<string, string?>(".Token.access_token", "abcdefghijklmnopqrstuvwxyz"),
+                new KeyValuePair<string, string?>(".Token.refresh_token", "1234567890"),
+                new KeyValuePair<string, string?>(".Token.token_type", "Bearer"),
+                new KeyValuePair<string, string?>(".TokenNames", "access_token;refresh_token;token_type;expires_at"),
+                new KeyValuePair<string, string?>(".Token.expires_at", DateTimeOffset.Now.AddDays(1).ToString("O"))
+            }
+        };
+
+        var cookieValueBytes = serviceScope.ServiceProvider.GetRequiredService<IDataProtectionProvider>()
+            .CreateProtector("Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationMiddleware", IdentityConstants.ApplicationScheme, "v2")
+            .Protect(TicketSerializer.Default.Serialize(new AuthenticationTicket(principal, authProperties, IdentityConstants.ApplicationScheme)));
+
+        var cookieName = CookieAuthenticationDefaults.CookiePrefix + Uri.EscapeDataString(IdentityConstants.ApplicationScheme);
+        var cookieValue = Base64UrlTextEncoder.Encode(cookieValueBytes);
+
+        var cookieContainer = new CookieContainer();
+
+        var setCookieHeader = new SetCookieHeaderValue(cookieName, cookieValue)
+        {
+            Path = "/",
+            HttpOnly = true,
+            Secure = false,
+            Expires = DateTimeOffset.Now.AddDays(1),
+            Domain = clientOptions.BaseAddress.Host,
+            SameSite = SameSiteMode.None
+        };
+
+        cookieContainer.SetCookies(clientOptions.BaseAddress, setCookieHeader.ToString());
+
+        return CreateDefaultClient(clientOptions.BaseAddress, CreateHandlersCore().ToArray());
+
+        IEnumerable<DelegatingHandler> CreateHandlersCore()
+        {
+            if (clientOptions.AllowAutoRedirect)
+            {
+                yield return new RedirectHandler(clientOptions.MaxAutomaticRedirections);
+            }
+
+            yield return new CookieContainerHandler(cookieContainer);
+        }
     }
 }

--- a/Web.IntegrationTests/TeamsTests.cs
+++ b/Web.IntegrationTests/TeamsTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using Web.Authorization;
 using Web.IntegrationTests.Common;
 
 namespace Web.IntegrationTests;
@@ -23,7 +24,8 @@ public class TeamsTests
     {
         // Arrange
         using var factory = new WebApplicationFactory();
-        using var client = factory.CreateAuthenticatedClient(await factory.TestUsers.GetPrincipal("testuser"));
+        await factory.TestUsers.CreateUser("director1", Roles.DirectorRole);
+        using var client = factory.CreateAuthenticatedClient(await factory.TestUsers.GetPrincipal("director1"));
         using var request = new HttpRequestMessage(HttpMethod.Get, "teams");
 
         // Act

--- a/Web.IntegrationTests/TeamsTests.cs
+++ b/Web.IntegrationTests/TeamsTests.cs
@@ -1,0 +1,35 @@
+﻿using FluentAssertions;
+using Web.IntegrationTests.Common;
+
+namespace Web.IntegrationTests;
+public class TeamsTests
+{
+    [Test]
+    public async Task GetAllTeams_WithoutAuthorization_Returns401Unauthorized()
+    {
+        // Arrange
+        using var client = new WebApplicationFactory().CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, "teams");
+
+        // Act
+        using var response = await client.SendAsync(request);
+
+        // Assert
+        response.Should().Be401Unauthorized();
+    }
+
+    [Test]
+    public async Task GetAllTeams_Returns200OK()
+    {
+        // Arrange
+        using var factory = new WebApplicationFactory();
+        using var client = factory.CreateAuthenticatedClient(await factory.TestUsers.GetPrincipal("testuser"));
+        using var request = new HttpRequestMessage(HttpMethod.Get, "teams");
+
+        // Act
+        using var response = await client.SendAsync(request);
+
+        // Assert
+        response.Should().BeSuccessful();
+    }
+}

--- a/Web.IntegrationTests/TeamsTests.cs
+++ b/Web.IntegrationTests/TeamsTests.cs
@@ -1,4 +1,7 @@
 ﻿using FluentAssertions;
+using FluentAssertions.Json;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
 using Web.Authorization;
 using Web.IntegrationTests.Common;
 
@@ -6,11 +9,14 @@ namespace Web.IntegrationTests;
 public class TeamsTests
 {
     [Test]
-    public async Task GetAllTeams_WithoutAuthorization_Returns401Unauthorized()
+    public async Task CreateTeam_WithoutAuthorization_Returns401Unauthorized()
     {
         // Arrange
         using var client = new WebApplicationFactory().CreateClient();
-        using var request = new HttpRequestMessage(HttpMethod.Get, "teams");
+        using var request = new HttpRequestMessage(HttpMethod.Post, "teams")
+        {
+            Content = JsonContent.Create(new { name = "Team 1" })
+        };
 
         // Act
         using var response = await client.SendAsync(request);
@@ -20,18 +26,30 @@ public class TeamsTests
     }
 
     [Test]
-    public async Task GetAllTeams_Returns200OK()
+    public async Task TeamsListSerializesCorrectly()
     {
         // Arrange
         using var factory = new WebApplicationFactory();
         await factory.TestUsers.CreateUser("director1", Roles.DirectorRole);
         using var client = factory.CreateAuthenticatedClient(await factory.TestUsers.GetPrincipal("director1"));
-        using var request = new HttpRequestMessage(HttpMethod.Get, "teams");
+        using var request = new HttpRequestMessage(HttpMethod.Post, "teams")
+        {
+            Content = JsonContent.Create(new { name = "Team 1" })
+        };
 
         // Act
         using var response = await client.SendAsync(request);
 
         // Assert
         response.Should().BeSuccessful();
+        var content = await response.Content.ReadFromJsonAsync<JsonObject>();
+        content.Should().NotBeNull().And.Contain(kvp => kvp.Key == "name" && JsonNode.DeepEquals(kvp.Value, "Team 1"));
+
+        using var teamsRequest = new HttpRequestMessage(HttpMethod.Get, "teams");
+        using var teamsResponse = await client.SendAsync(teamsRequest);
+        teamsResponse.Should().BeSuccessful();
+        var teamsContent = await teamsResponse.Content.ReadFromJsonAsync<JsonArray>();
+        teamsContent.Should().NotBeNull().And.HaveCount(1);
+        teamsContent![0].Should().NotBeNull().And.BeOfType<JsonObject>().Which.Should().Contain(kvp => kvp.Key == "name" && JsonNode.DeepEquals(kvp.Value, "Team 1"));
     }
 }

--- a/Web.UnitTests/Controllers/TeamsControllerTests.cs
+++ b/Web.UnitTests/Controllers/TeamsControllerTests.cs
@@ -1,0 +1,30 @@
+﻿using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Web.Controllers;
+using Web.Model;
+using Web.UnitTests.Fakes;
+
+namespace Web.UnitTests.Controllers;
+internal class TeamsControllerTests
+{
+    [Test]
+    public async Task GetAllTeams_ReturnsAllTeams()
+    {
+        // Arrange
+        var uow = new FakeUnitOfWork();
+        uow.Repository<Team>().AddRange([
+            new Team(1) { Name = "Team 1" },
+            new Team(2) { Name = "Team 1" },
+            new Team(3) { Name = "Team 1" }]);
+        await uow.CompleteAsync();
+
+        var controller = new TeamsController(uow);
+        // Act
+        var result = await controller.GetAllTeams();
+        // Assert
+        result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().NotBeNull()
+            .And.BeAssignableTo<IEnumerable<TeamResponse>>()
+            .Which.Should().HaveCount(3);
+    }
+}

--- a/Web.UnitTests/Controllers/TeamsControllerTests.cs
+++ b/Web.UnitTests/Controllers/TeamsControllerTests.cs
@@ -19,12 +19,71 @@ internal class TeamsControllerTests
         await uow.CompleteAsync();
 
         var controller = new TeamsController(uow);
+
         // Act
         var result = await controller.GetAllTeams();
+
         // Assert
         result.Should().BeOfType<OkObjectResult>()
             .Which.Value.Should().NotBeNull()
             .And.BeAssignableTo<IEnumerable<TeamResponse>>()
             .Which.Should().HaveCount(3);
+    }
+
+    [Test]
+    public async Task GetTeam_ReturnsTeam()
+    {
+        // Arrange
+        var uow = new FakeUnitOfWork();
+        var team = new Team(1) { Name = "Team 1" };
+        uow.Repository<Team>().Add(team);
+        await uow.CompleteAsync();
+        var controller = new TeamsController(uow);
+
+        // Act
+        var result = await controller.GetTeam(1);
+
+        // Assert
+        var teamResp = result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().NotBeNull()
+            .And.BeOfType<TeamResponse>().Subject;
+        teamResp.Name.Should().Be("Team 1");
+    }
+
+    [Test]
+    public async Task CreateTeam_ReturnsCreatedTeam()
+    {
+        // Arrange
+        var uow = new FakeUnitOfWork();
+        var controller = new TeamsController(uow);
+
+        // Act
+        var result = await controller.CreateTeam(new CreateTeamRequest("Team 1"), () => 1);
+
+        // Assert
+        var teamResp = result.Should().BeOfType<CreatedAtActionResult>()
+            .Which.Value.Should().NotBeNull()
+            .And.BeOfType<TeamResponse>().Subject;
+        teamResp.Name.Should().Be("Team 1");
+    }
+
+    [Test]
+    public async Task UpdateTeam_ReturnsUpdatedTeam()
+    {
+        // Arrange
+        var uow = new FakeUnitOfWork();
+        var team = new Team(1) { Name = "Team 1" };
+        uow.Repository<Team>().Add(team);
+        await uow.CompleteAsync();
+        var controller = new TeamsController(uow);
+
+        // Act
+        var result = await controller.UpdateTeam(1, new CreateTeamRequest("Team 2"));
+
+        // Assert
+        var teamResp = result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().NotBeNull()
+            .And.BeOfType<TeamResponse>().Subject;
+        teamResp.Name.Should().Be("Team 2");
     }
 }

--- a/Web/Authorization/DriverDatabaseIdentityExtensions.cs
+++ b/Web/Authorization/DriverDatabaseIdentityExtensions.cs
@@ -7,7 +7,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Web.Model.EF;
 
-namespace Web;
+namespace Web.Authorization;
 
 static class DriverDatabaseIdentityExtensions
 {

--- a/Web/Authorization/Policies.cs
+++ b/Web/Authorization/Policies.cs
@@ -1,0 +1,9 @@
+﻿namespace Web.Authorization;
+
+/// <summary>
+/// Helper class to store the names of the policies used in the application.
+/// </summary>
+public class Policies
+{
+    public const string IsDirector = "IsDirector";
+}

--- a/Web/Authorization/RoleAutoUpdates/GenerateRolesHostedService.cs
+++ b/Web/Authorization/RoleAutoUpdates/GenerateRolesHostedService.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.AspNetCore.Identity;
+using System.Threading.Channels;
+
+namespace Web.Authorization.RoleAutoUpdates;
+
+class GenerateRolesHostedService(
+    IServiceProvider serviceProvider,
+    ChannelReader<RolesConfiguration> reader) : BackgroundService
+{
+    readonly IServiceProvider serviceProvider = serviceProvider;
+    readonly ChannelReader<RolesConfiguration> reader = reader;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (await reader.ReadAsync(stoppingToken) is RolesConfiguration configuration)
+        {
+            using var scope = serviceProvider.CreateScope();
+            var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+            var existingRoles = roleManager.Roles
+                .Select(r => r.Name)
+                .Where(r => r != null)
+                .OfType<string>()
+                .ToArray();
+
+            var newRoles = configuration.ApplicationRoles.Except(existingRoles);
+            foreach (var role in newRoles)
+                await roleManager.CreateAsync(new IdentityRole(role));
+
+            var roles = roleManager.Roles.ToList();
+        }
+    }
+}

--- a/Web/Authorization/RoleAutoUpdates/PropagateRolesConfigurationChangesHostedService.cs
+++ b/Web/Authorization/RoleAutoUpdates/PropagateRolesConfigurationChangesHostedService.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.Extensions.Options;
+using System.Threading.Channels;
+
+namespace Web.Authorization.RoleAutoUpdates;
+
+class PropagateRolesConfigurationChangesHostedService(
+    IOptionsMonitor<RolesConfiguration> monitorConfiguration,
+    ChannelWriter<RolesConfiguration> writer) : IHostedService, IDisposable
+{
+    readonly IOptionsMonitor<RolesConfiguration> monitorConfiguration = monitorConfiguration;
+    readonly ChannelWriter<RolesConfiguration> writer = writer;
+    IDisposable? optionsMonitorListener;
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        optionsMonitorListener = monitorConfiguration.OnChange(RolesConfigurationChanged);
+        await writer.WriteAsync(monitorConfiguration.CurrentValue, cancellationToken);
+    }
+
+    void RolesConfigurationChanged(RolesConfiguration configuration)
+    {
+        if (!writer.TryWrite(configuration))
+            throw new InvalidOperationException("Failed to write configuration change to channel");
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        optionsMonitorListener?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    #region IDisposable Support
+    bool disposedValue;
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposedValue)
+        {
+            if (disposing)
+                optionsMonitorListener?.Dispose();
+
+            disposedValue = true;
+        }
+    }
+
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+    #endregion
+}

--- a/Web/Authorization/RoleUpdaterExtensions.cs
+++ b/Web/Authorization/RoleUpdaterExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading.Channels;
+using Web.Authorization.RoleAutoUpdates;
+
+namespace Web.Authorization;
+
+public static class RoleUpdaterExtensions
+{
+    /// <summary>
+    /// Adds automatic role updates.
+    /// </summary>
+    /// <param name="services"></param>
+    /// <param name="configuration">A <see cref="IConfigurationSection"/> that can bind to a <see cref="RolesConfiguration"/> instance.</param>
+    /// <returns></returns>
+    public static IServiceCollection AddAutomaticRoleUpdates(this IServiceCollection services, IConfigurationSection configuration)
+    {
+        services.AddOptions<RolesConfiguration>()
+            .Bind(configuration)
+            .ValidateDataAnnotations();
+
+        services.AddSingleton(Channel.CreateUnbounded<RolesConfiguration>());
+        services.AddSingleton(sp => sp.GetRequiredService<Channel<RolesConfiguration>>().Reader);
+        services.AddSingleton(sp => sp.GetRequiredService<Channel<RolesConfiguration>>().Writer);
+        services.AddHostedService<PropagateRolesConfigurationChangesHostedService>();
+        services.AddHostedService<GenerateRolesHostedService>();
+        return services;
+    }
+}

--- a/Web/Authorization/Roles.cs
+++ b/Web/Authorization/Roles.cs
@@ -1,0 +1,9 @@
+﻿namespace Web.Authorization;
+
+/// <summary>
+/// Helper class to store the names of the roles used in the application.
+/// </summary>
+public class Roles
+{
+    public const string DirectorRole = "Director";
+}

--- a/Web/Authorization/RolesConfiguration.cs
+++ b/Web/Authorization/RolesConfiguration.cs
@@ -1,0 +1,7 @@
+﻿namespace Web.Authorization;
+
+class RolesConfiguration
+{
+    public const string ConfigurationSection = "Authentication:Roles";
+    public IEnumerable<string> ApplicationRoles { get; set; } = [];
+}

--- a/Web/Controllers/TeamsController.cs
+++ b/Web/Controllers/TeamsController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Web.Authorization;
 using Web.Model;
 using Web.Model.Repository;
 using Web.Types;
@@ -7,16 +8,54 @@ using Web.Utils;
 
 namespace Web.Controllers;
 
-public record class TeamResponse(Snowflake Id, string Name);
+public record class TeamResponse(Snowflake Id, string Name)
+{
+    public TeamResponse(Team team) : this(team.TeamId, team.Name) { }
+}
+public record class CreateTeamRequest(string Name);
 
 [Route("teams")]
 public class TeamsController(IUnitOfWork unitOfWork) : ControllerBase
 {
     private readonly IUnitOfWork unitOfWork = unitOfWork;
 
-    [HttpGet, Authorize(Policy = "IsDirector")]
+    [HttpGet]
     public async Task<IActionResult> GetAllTeams()
     {
-        return Ok(await unitOfWork.Repository<Team>().Query().Select(t => new TeamResponse(t.TeamId, t.Name)).ToListAsync());
+        return Ok(await unitOfWork.Repository<Team>().Query().Select(t => new TeamResponse(t)).ToListAsync());
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetTeam(Snowflake id)
+    {
+        var team = await unitOfWork.Repository<Team>().GetByIdAsync(id);
+        if (team is null)
+            return NotFound();
+
+        return Ok(new TeamResponse(team.TeamId, team.Name));
+    }
+
+    [HttpPost, Authorize(Policies.IsDirector)]
+    public async Task<IActionResult> CreateTeam([FromBody] CreateTeamRequest createTeamRequest, [FromServices] GenerateId generateId)
+    {
+        var team = new Team(generateId())
+        {
+            Name = createTeamRequest.Name
+        };
+        unitOfWork.Repository<Team>().Add(team);
+        await unitOfWork.CompleteAsync();
+        return CreatedAtAction(nameof(GetTeam), new { id = team.TeamId }, new TeamResponse(team));
+    }
+
+    [HttpPut("{id}"), Authorize(Policies.IsDirector)]
+    public async Task<IActionResult> UpdateTeam(Snowflake id, [FromBody] CreateTeamRequest createTeamRequest)
+    {
+        var team = await unitOfWork.Repository<Team>().GetByIdAsync(id);
+        if (team is null)
+            return NotFound();
+
+        team.Name = createTeamRequest.Name;
+        await unitOfWork.CompleteAsync();
+        return Ok(new TeamResponse(team));
     }
 }

--- a/Web/Controllers/TeamsController.cs
+++ b/Web/Controllers/TeamsController.cs
@@ -14,7 +14,7 @@ public class TeamsController(IUnitOfWork unitOfWork) : ControllerBase
 {
     private readonly IUnitOfWork unitOfWork = unitOfWork;
 
-    [HttpGet, Authorize]
+    [HttpGet, Authorize(Policy = "IsDirector")]
     public async Task<IActionResult> GetAllTeams()
     {
         return Ok(await unitOfWork.Repository<Team>().Query().Select(t => new TeamResponse(t.TeamId, t.Name)).ToListAsync());

--- a/Web/Controllers/TeamsController.cs
+++ b/Web/Controllers/TeamsController.cs
@@ -1,14 +1,22 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Web.Model;
+using Web.Model.Repository;
+using Web.Types;
+using Web.Utils;
 
 namespace Web.Controllers;
 
+public record class TeamResponse(Snowflake Id, string Name);
+
 [Route("teams")]
-public class TeamsController : ControllerBase
+public class TeamsController(IUnitOfWork unitOfWork) : ControllerBase
 {
+    private readonly IUnitOfWork unitOfWork = unitOfWork;
+
     [HttpGet, Authorize]
     public async Task<IActionResult> GetAllTeams()
     {
-        return Ok();
+        return Ok(await unitOfWork.Repository<Team>().Query().Select(t => new TeamResponse(t.TeamId, t.Name)).ToListAsync());
     }
 }

--- a/Web/Controllers/TeamsController.cs
+++ b/Web/Controllers/TeamsController.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Web.Controllers;
+
+[Route("teams")]
+public class TeamsController : ControllerBase
+{
+    [HttpGet, Authorize]
+    public async Task<IActionResult> GetAllTeams()
+    {
+        return Ok();
+    }
+}

--- a/Web/Migrations/20250103205230_CreateTeamModel.Designer.cs
+++ b/Web/Migrations/20250103205230_CreateTeamModel.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Web.Model.EF;
 
@@ -10,9 +11,11 @@ using Web.Model.EF;
 namespace Web.Migrations
 {
     [DbContext(typeof(DriverDatabaseContext))]
-    partial class DriverDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20250103205230_CreateTeamModel")]
+    partial class CreateTeamModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.11");

--- a/Web/Migrations/20250103205230_CreateTeamModel.cs
+++ b/Web/Migrations/20250103205230_CreateTeamModel.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Web.Migrations
+{
+    /// <inheritdoc />
+    public partial class CreateTeamModel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Teams",
+                columns: table => new
+                {
+                    TeamId = table.Column<long>(type: "INTEGER", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Teams", x => x.TeamId);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Teams");
+        }
+    }
+}

--- a/Web/Model/EF/DriverDatabaseContext.cs
+++ b/Web/Model/EF/DriverDatabaseContext.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Web.Types;
@@ -9,6 +8,7 @@ namespace Web.Model.EF;
 public class DriverDatabaseContext(DbContextOptions options) : IdentityDbContext(options)
 {
     public DbSet<Driver> Drivers { get; set; }
+    public DbSet<Team> Teams { get; set; }
 
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {

--- a/Web/Model/Team.cs
+++ b/Web/Model/Team.cs
@@ -1,0 +1,9 @@
+﻿using Web.Types;
+
+namespace Web.Model;
+
+public class Team(Snowflake teamId)
+{
+    public Snowflake TeamId { get; private set; } = teamId;
+    public string Name { get; set; } = string.Empty;
+}

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -32,6 +32,8 @@ public class Program
         {
             opts.AddPolicy(Policies.IsDirector, policy => policy.RequireRole(Roles.DirectorRole));
         });
+        builder.Services.AddAutomaticRoleUpdates(builder.Configuration.GetRequiredSection(RolesConfiguration.ConfigurationSection));
+
         builder.Services.AddControllers().AddJsonOptions(options =>
         {
             options.JsonSerializerOptions.Converters.Add(new SnowflakeJsonConverter());

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Web.Authorization;
 using Web.Model.EF;
 using Web.Model.Repository;
 using Web.Types;

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -1,5 +1,6 @@
 using IdGen;
 using IdGen.DependencyInjection;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -27,6 +28,10 @@ public class Program
         builder.Services.AddIdGen(1);
         builder.Services.AddSingleton<GenerateId>(sp => () => new(sp.GetRequiredService<IIdGenerator<long>>().CreateId()));
         builder.Services.AddDriverDatabaseIdentity(builder.Configuration);
+        builder.Services.AddAuthorization(opts =>
+        {
+            opts.AddPolicy(Policies.IsDirector, policy => policy.RequireRole(Roles.DirectorRole));
+        });
         builder.Services.AddControllers().AddJsonOptions(options =>
         {
             options.JsonSerializerOptions.Converters.Add(new SnowflakeJsonConverter());

--- a/Web/appsettings.json
+++ b/Web/appsettings.json
@@ -9,6 +9,9 @@
     "Discord": {
       "ClientId": "in-user-secrets-see-readme",
       "ClientSecret": "in-user-secrets-see-readme"
+    },
+    "Roles": {
+      "ApplicationRoles": [ "Director" ]
     }
   },
   "Database": {


### PR DESCRIPTION
Adds the Teams endpoints and supporting test infrastructure.
This being the first authenticated endpoint, a good amount of test infrastructure was needed to support registering and authenticating with the integration testing API. This PR adds helper methods to concisely manage and authenticate as users in integration tests.

The Teams create/update endpoints are secured so only users with the Director role can modify them. Read methods are unsecured.